### PR TITLE
Bug-fix Site-Header Search

### DIFF
--- a/web/app/themes/plantchicago/assets/scripts/main.js
+++ b/web/app/themes/plantchicago/assets/scripts/main.js
@@ -124,14 +124,14 @@ var PlantChicago = (function($) {
     $('.search-toggle').on('click', function() {
       $('.site-header .search-form').addClass('-active');
       setTimeout( function() {
-        // $('.site-header .search-field:first').focus();
+        $('.site-header .search-field:first').focus();
       },500);
     });
 
     // Hide header search form when clicking away
     $('body').on('click', function(e) {
       if ($('.site-header .search-form').is('.-active') && !$(e.target).closest('.search-toggle').length && !$(e.target).closest('.search-form').length) {
-        // _hideSearch(); 
+        _hideSearch(); 
       }
     });
 

--- a/web/app/themes/plantchicago/assets/scripts/main.js
+++ b/web/app/themes/plantchicago/assets/scripts/main.js
@@ -121,16 +121,21 @@ var PlantChicago = (function($) {
   }
 
   function _initSearch() {
-    $('.search-toggle').on('click', function() {
-      $('.site-header .search-form').addClass('-active');
-      setTimeout( function() {
-        $('.site-header .search-field:first').focus();
-      },500);
+
+    // Show on click or focus of search-toggle
+    $('.search-toggle').on('click focus', function(e) {
+      e.preventDefault();
+      _openSearch();
+    });
+
+    // Show on focus of field itself
+    $('.site-header .search-field').focus(function(e){
+      _openSearch();
     });
 
     // Hide header search form when clicking away
     $('body').on('click', function(e) {
-      if ($('.site-header .search-form').is('.-active') && !$(e.target).closest('.search-toggle').length && !$(e.target).closest('.search-form').length) {
+      if ($('.site-header .search-form').is('.-active') && !$(e.target).closest('.search-toggle').length && !$(e.target).closest('.site-header .search-field').length) {
         _hideSearch(); 
       }
     });
@@ -140,14 +145,26 @@ var PlantChicago = (function($) {
       _hideSearch();
     });
 
+    // Hide with close button
     $('.search-form .close-button').on('click', function() {
       _hideSearch();
     });
   }
+  
+  function _openSearch() {
+    if(!$('.site-header .search-form').hasClass('-active')) {
+      $('.site-header .search-form').addClass('-active');
+      setTimeout( function() {
+        $('.site-header .search-field').focus();
+      },500);
+    }
+  }
 
   function _hideSearch() {
     $('.search-form').removeClass('-active');
-    $('.search-field').blur();
+    if( $('.search-form .search-field').is(':focus') ){ // Must test for this or we will recursively blur (_hideSearch is called on blur)
+      $('.search-form .search-field').blur();
+    }
   }
 
   // Handles main nav

--- a/web/app/themes/plantchicago/assets/scripts/main.js
+++ b/web/app/themes/plantchicago/assets/scripts/main.js
@@ -121,16 +121,17 @@ var PlantChicago = (function($) {
   }
 
   function _initSearch() {
-    $('.search-toggle').on('click, focus', function() {
+    $('.search-toggle').on('click', function() {
       $('.site-header .search-form').addClass('-active');
-      $('.site-header .search-field:first').focus();
+      setTimeout( function() {
+        // $('.site-header .search-field:first').focus();
+      },500);
     });
 
     // Hide header search form when clicking away
-    $('html, body').on('click', function(e) {
-      if ($('.site-header .search-form').is('.-active') && !$(e.target).closest('.search-toggle').length) {
-        console.log(e.target);
-        _hideSearch(); 
+    $('body').on('click', function(e) {
+      if ($('.site-header .search-form').is('.-active') && !$(e.target).closest('.search-toggle').length && !$(e.target).closest('.search-form').length) {
+        // _hideSearch(); 
       }
     });
 

--- a/web/app/themes/plantchicago/assets/styles/components/_search.scss
+++ b/web/app/themes/plantchicago/assets/styles/components/_search.scss
@@ -33,7 +33,7 @@
   position: relative;
 
   input {
-    outline-offset: 0;
+    outline-offset: 0; // Prevents resizing of outline on focus in Chrome
     width: 100%;
     border: none;
     height: 36px;

--- a/web/app/themes/plantchicago/assets/styles/components/_search.scss
+++ b/web/app/themes/plantchicago/assets/styles/components/_search.scss
@@ -33,12 +33,12 @@
   position: relative;
 
   input {
+    outline-offset: 0;
     width: 100%;
     border: none;
     height: 36px;
     padding: 0 18px;
     font-size: 16px;
-    line-height: 36px;
     background: $white;
     &:focus {
       outline: 1px solid $brand-secondary;
@@ -53,7 +53,7 @@
     border: none;
     padding: 4px 0 0 0;
     position: absolute;
-    background: $white;
+    background: transparent;
     &:focus {
       outline: none;
     }
@@ -72,7 +72,6 @@
 
     input {
       height: 72px;
-      line-height: 72px;
       padding-right: 70px;
     }
   }

--- a/web/app/themes/plantchicago/assets/styles/components/_ui-componenets.scss
+++ b/web/app/themes/plantchicago/assets/styles/components/_ui-componenets.scss
@@ -172,6 +172,7 @@
     right: 0;
     bottom: 0;
     position: absolute;
+    transform: translateZ(0); // A hack to keep the :before and :after (which because rotated involve fractional pixels) from dancing around on screen resize due to browser rounding in Chrome
     &:before,
     &:after {
       left: 50%;


### PR DESCRIPTION
Made a few cross-browser compatibility fixes to the search in the site-header:

- Transitions in without pushing content
- Opens in Firefox/Safari
- Does not recursively call blur
- X ui element uses 3d-HA to prevent distortion at certain screen sizes
- Does not close upon clicking within the search
- Line-height fix for proper caret sizing in firefox